### PR TITLE
Update init.coffee

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -67,6 +67,7 @@ module.exports =
 
   provideLinter: ->
     provider =
+      name: 'pydocstyle'
       grammarScopes: ['source.python']
       scope: 'file'
       lintOnFly: false


### PR DESCRIPTION
Added `name: 'pydocstyle'` to `provideLinter`. Fixes pydocstyle showing as an "Unknown" provider with [linter-ui-default](https://github.com/steelbrain/linter-ui-default). It should now show as "pydocstyle".

See https://github.com/steelbrain/linter-ui-default/issues/242.